### PR TITLE
Ensure cargo is run in the rust project's toplevel directory

### DIFF
--- a/lib/thermite/cargo.rb
+++ b/lib/thermite/cargo.rb
@@ -37,7 +37,9 @@ module Thermite
     # Run `cargo` with the given `args` and return `STDOUT`.
     #
     def run_cargo(*args)
-      sh "#{cargo} #{Shellwords.join(args)}"
+      Dir.chdir(config.rust_toplevel_dir) do
+        sh "#{cargo} #{Shellwords.join(args)}"
+      end
     end
 
     #


### PR DESCRIPTION
@d-unseductable, please let me know if this fixes your issue.

Fixes #7.