### PR TITLE
Make library_name consistent with Cargo re: hyphens

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+* The library name is consistent with how Cargo handles hyphens (#19)
+
 ## [0.8.0] - 2016-12-05
 
 ### Added

--- a/lib/thermite/config.rb
+++ b/lib/thermite/config.rb
@@ -99,13 +99,12 @@ module Thermite
     #
     # The name of the library compiled by Rust.
     #
+    # Due to the way that Cargo works, all hyphens in library names are replaced with underscores.
+    #
     def library_name
       @library_name ||= begin
-        if toml[:lib] && toml[:lib][:name]
-          toml[:lib][:name]
-        else
-          toml[:package][:name]
-        end
+        base = toml[:lib] && toml[:lib][:name] ? toml[:lib] : toml[:package]
+        base[:name].tr('-', '_') if base[:name]
       end
     end
 

--- a/test/lib/thermite/config_test.rb
+++ b/test/lib/thermite/config_test.rb
@@ -41,6 +41,16 @@ module Thermite
       assert_equal 'barbaz', config.library_name
     end
 
+    def test_library_name_from_cargo_lib_has_no_hyphens
+      config.stubs(:toml).returns(lib: { name: 'foo-bar' }, package: { name: 'bar-baz' })
+      assert_equal 'foo_bar', config.library_name
+    end
+
+    def test_library_name_from_cargo_package_has_no_hyphens
+      config.stubs(:toml).returns(lib: {}, package: { name: 'bar-baz' })
+      assert_equal 'bar_baz', config.library_name
+    end
+
     def test_shared_library
       config.stubs(:library_name).returns('foobar')
       config.stubs(:shared_ext).returns('ext')


### PR DESCRIPTION
Replace all instances of hyphens in the `library_name` with underscores.

Fixes #19.

CC: @d-unseductable