### PR TITLE
Update cargo.rb for cargo directory with spaces

### DIFF
--- a/lib/thermite/cargo.rb
+++ b/lib/thermite/cargo.rb
@@ -38,7 +38,7 @@ module Thermite
     #
     def run_cargo(*args)
       Dir.chdir(config.rust_toplevel_dir) do
-        sh "#{cargo} #{Shellwords.join(args)}"
+        sh %Q("#{cargo}" #{Shellwords.join(args)})
       end
     end
 


### PR DESCRIPTION
If cargo is installed in a directory with spaces, this quotes the path