### PR TITLE
Replace `cargo build` call with `cargo rustc`

### DIFF
--- a/lib/thermite/cargo.rb
+++ b/lib/thermite/cargo.rb
@@ -59,6 +59,17 @@ module Thermite
     end
 
     #
+    # Run `cargo rustc`, given a target (i.e., `release [default] or `debug`).
+    #
+    def run_cargo_rustc(target)
+      cargo_args = %w(rustc)
+      cargo_args << '--release' if target == 'release'
+      cargo_args.push(*cargo_rustc_args)
+      puts "Running: cargo #{cargo_args.join}"
+      run_cargo(*cargo_args)
+    end
+
+    #
     # Inform the user about cargo if it doesn't exist.
     #
     # If `optional_rust_extension` is true, print message to STDERR. Otherwise, raise an exception.
@@ -95,6 +106,21 @@ EOM
     #
     def cargo_recommended_msg
       cargo_msg('recommended (but not required)')
+    end
+
+    private
+
+    def cargo_rustc_args
+      args = []
+      unless config.dynamic_linker_flags == ''
+        args.push(
+          '--',
+          '-C',
+          "link-args=#{Shellwords.escape(config.dynamic_linker_flags)}"
+        )
+      end
+
+      args
     end
   end
 end

--- a/lib/thermite/cargo.rb
+++ b/lib/thermite/cargo.rb
@@ -65,7 +65,6 @@ module Thermite
       cargo_args = %w(rustc)
       cargo_args << '--release' if target == 'release'
       cargo_args.push(*cargo_rustc_args)
-      puts "Running: cargo #{cargo_args.join}"
       run_cargo(*cargo_args)
     end
 

--- a/lib/thermite/cargo.rb
+++ b/lib/thermite/cargo.rb
@@ -50,7 +50,7 @@ module Thermite
     end
 
     #
-    # Run `cargo rustc`, given a target (i.e., `release [default] or `debug`).
+    # Run `cargo rustc`, given a target (i.e., `release` [default] or `debug`).
     #
     def run_cargo_rustc(target)
       cargo_args = %w(rustc)

--- a/lib/thermite/cargo.rb
+++ b/lib/thermite/cargo.rb
@@ -50,15 +50,6 @@ module Thermite
     end
 
     #
-    # Run `cargo build`, given a target (i.e., `release` [default] or `debug`).
-    #
-    def run_cargo_build(target)
-      cargo_args = %w(build)
-      cargo_args << '--release' if target == 'release'
-      run_cargo(*cargo_args)
-    end
-
-    #
     # Run `cargo rustc`, given a target (i.e., `release [default] or `debug`).
     #
     def run_cargo_rustc(target)

--- a/lib/thermite/cargo.rb
+++ b/lib/thermite/cargo.rb
@@ -116,7 +116,7 @@ EOM
         args.push(
           '--',
           '-C',
-          "link-args=#{Shellwords.escape(config.dynamic_linker_flags)}"
+          "link-args=#{config.dynamic_linker_flags}"
         )
       end
 

--- a/lib/thermite/config.rb
+++ b/lib/thermite/config.rb
@@ -212,19 +212,19 @@ module Thermite
       end
     end
 
+    #
+    # Linker flags for libruby.
+    #
+    def dynamic_linker_flags
+      @dynamic_linker_flags ||= RbConfig::CONFIG['DLDFLAGS']
+    end
+
     private
 
     # :nocov:
 
     def dlext
       RbConfig::CONFIG['DLEXT']
-    end
-
-    #
-    # Linker flags for libruby.
-    #
-    def dynamic_linker_flags
-      @dynamic_linker_flags ||= RbConfig::CONFIG['DLDFLAGS']
     end
 
     def rbconfig_ruby_version

--- a/lib/thermite/config.rb
+++ b/lib/thermite/config.rb
@@ -220,6 +220,13 @@ module Thermite
       RbConfig::CONFIG['DLEXT']
     end
 
+    #
+    # Linker flags for libruby.
+    #
+    def dynamic_linker_flags
+      @dynamic_linker_flags ||= RbConfig::CONFIG['DLDFLAGS']
+    end
+
     def rbconfig_ruby_version
       RbConfig::CONFIG['ruby_version']
     end

--- a/lib/thermite/config.rb
+++ b/lib/thermite/config.rb
@@ -212,6 +212,8 @@ module Thermite
       end
     end
 
+    # :nocov:
+
     #
     # Linker flags for libruby.
     #
@@ -220,8 +222,6 @@ module Thermite
     end
 
     private
-
-    # :nocov:
 
     def dlext
       RbConfig::CONFIG['DLEXT']

--- a/lib/thermite/tasks.rb
+++ b/lib/thermite/tasks.rb
@@ -118,7 +118,8 @@ module Thermite
         # if cargo found, build. Otherwise, grab binary (when github_releases is enabled).
         if cargo
           target = ENV.fetch('CARGO_TARGET', 'release')
-          run_cargo_build(target)
+          # run_cargo_build(target)
+          run_cargo_rustc(target)
           FileUtils.cp(config.rust_path('target', target, config.shared_library),
                        config.ruby_path('lib'))
         elsif !download_binary_from_custom_uri && !download_binary_from_github_release

--- a/lib/thermite/tasks.rb
+++ b/lib/thermite/tasks.rb
@@ -118,7 +118,6 @@ module Thermite
         # if cargo found, build. Otherwise, grab binary (when github_releases is enabled).
         if cargo
           target = ENV.fetch('CARGO_TARGET', 'release')
-          # run_cargo_build(target)
           run_cargo_rustc(target)
           FileUtils.cp(config.rust_path('target', target, config.shared_library),
                        config.ruby_path('lib'))

--- a/test/lib/thermite/cargo_test.rb
+++ b/test/lib/thermite/cargo_test.rb
@@ -22,14 +22,22 @@ module Thermite
       mock_module.run_cargo_if_exists('foo', 'bar')
     end
 
-    def test_run_cargo_debug_build
-      mock_module.expects(:run_cargo).with('build').once
-      mock_module.run_cargo_build('debug')
+    def test_run_cargo_debug_rustc
+      mock_module.config.stubs(:dynamic_linker_flags).returns('')
+      mock_module.expects(:run_cargo).with('rustc').once
+      mock_module.run_cargo_rustc('debug')
     end
 
-    def test_run_cargo_release_build
-      mock_module.expects(:run_cargo).with('build', '--release').once
-      mock_module.run_cargo_build('release')
+    def test_run_cargo_release_rustc
+      mock_module.config.stubs(:dynamic_linker_flags).returns('')
+      mock_module.expects(:run_cargo).with('rustc', '--release').once
+      mock_module.run_cargo_rustc('release')
+    end
+
+    def test_run_cargo_rustc_with_dynamic_linker_flags
+      mock_module.config.stubs(:dynamic_linker_flags).returns('foo bar')
+      mock_module.expects(:run_cargo).with('rustc', '--', '-C', 'link-args=foo bar').once
+      mock_module.run_cargo_rustc('debug')
     end
 
     def test_inform_user_about_cargo_exception


### PR DESCRIPTION
Using `cargo rustc` has the advantage of utilizing the linker flags for libruby, made available via rbconfig's `RbConfig::CONFIG['DLDFLAGS']`.