### PR TITLE
Adjust library paths when the extension is a dylib

### DIFF
--- a/lib/thermite/config.rb
+++ b/lib/thermite/config.rb
@@ -142,6 +142,17 @@ module Thermite
       File.join(ruby_toplevel_dir, *path_components)
     end
 
+    # :nocov:
+
+    #
+    # Absolute path to the shared libruby.
+    #
+    def libruby_path
+      @libruby_path ||= File.join(RbConfig::CONFIG['libdir'], RbConfig::CONFIG['LIBRUBY_SO'])
+    end
+
+    # :nocov:
+
     #
     # The top-level directory of the Cargo project. Defaults to the current working directory.
     #

--- a/lib/thermite/custom_binary.rb
+++ b/lib/thermite/custom_binary.rb
@@ -48,6 +48,7 @@ module Thermite
 
       debug "Unpacking binary from Cargo version: #{File.basename(uri)}"
       unpack_tarball(tgz)
+      prepare_downloaded_library
       true
     end
 

--- a/lib/thermite/github_release_binary.rb
+++ b/lib/thermite/github_release_binary.rb
@@ -61,6 +61,7 @@ module Thermite
 
       debug "Unpacking GitHub release from Cargo version: #{File.basename(uri)}"
       unpack_tarball(tgz)
+      prepare_downloaded_library
       true
     end
 
@@ -75,6 +76,7 @@ module Thermite
         next unless tgz
         debug "Unpacking GitHub release: #{File.basename(download_uri)}"
         unpack_tarball(tgz)
+        prepare_downloaded_library
         installed_binary = true
         break
       end

--- a/test/lib/thermite/custom_binary_test.rb
+++ b/test/lib/thermite/custom_binary_test.rb
@@ -26,6 +26,7 @@ module Thermite
       Net::HTTP.stubs(:get_response).returns('location' => 'redirect')
       mock_module.stubs(:http_get).returns('tarball')
       mock_module.expects(:unpack_tarball).once
+      mock_module.expects(:prepare_downloaded_library).once
 
       assert mock_module.download_binary_from_custom_uri
     end

--- a/test/lib/thermite/github_release_binary_test.rb
+++ b/test/lib/thermite/github_release_binary_test.rb
@@ -56,6 +56,7 @@ module Thermite
       Net::HTTP.stubs(:get_response).returns('location' => 'redirect')
       mock_module.stubs(:http_get).returns('tarball')
       mock_module.expects(:unpack_tarball).once
+      mock_module.expects(:prepare_downloaded_library).once
 
       assert mock_module.download_binary_from_github_release
     end
@@ -67,6 +68,7 @@ module Thermite
       Net::HTTP.stubs(:get_response).returns('location' => 'redirect')
       mock_module.stubs(:http_get).returns('tarball')
       mock_module.expects(:unpack_tarball).once
+      mock_module.expects(:prepare_downloaded_library).once
 
       assert mock_module.download_binary_from_github_release
     end
@@ -114,6 +116,7 @@ module Thermite
       stub_releases_atom
       mock_module.stubs(:download_versioned_github_release_binary).returns(StringIO.new('tarball'))
       mock_module.expects(:unpack_tarball).once
+      mock_module.expects(:prepare_downloaded_library).once
 
       assert mock_module.download_binary_from_github_release
     end
@@ -131,6 +134,7 @@ module Thermite
       stub_releases_atom
       mock_module.stubs(:download_versioned_github_release_binary).returns(nil)
       mock_module.expects(:unpack_tarball).never
+      mock_module.expects(:prepare_downloaded_library).never
 
       assert !mock_module.download_binary_from_github_release
     end


### PR DESCRIPTION
OSX is the only supported OS that hardcodes library paths inside the built library, so we work around this by updating these paths when we download the binary.

Based on instructions from https://www.cairographics.org/end_to_end_build_for_mac_os_x/.

Tested with rusty_blank.