### PR TITLE
Add support for Cargo workspaces

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,10 @@ AllCops:
   - 'vendor/**/*'
   TargetRubyVersion: 2.1
 
+Lint/EndAlignment:
+  Enabled: true
+  EnforcedStyleAlignWith: variable
+
 Metrics/AbcSize:
   Max: 20
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,10 @@ Possible options:
   Example: `https://example.com/download/%{version}/%{filename}`. Replacement variables:
     - `filename` - The value of `Config.tarball_filename`
     - `version` - the crate version from `Cargo.toml`
-* `cargo_project_path` - the path to the Cargo project. Defaults to the current working directory.
+* `cargo_project_path` - the path to the top-level Cargo project. Defaults to the current working
+  directory.
+* `cargo_workspace_member` - if set, the relative path to the Cargo workspace member. Usually used
+  when it is part of a repository containing multiple crates.
 * `github_releases` - whether to look for Rust binaries via GitHub releases when installing
   the gem, and `cargo` is not found. Defaults to `false`.
 * `github_release_type` - when `github_releases` is `true`, the mode to use to download the Rust

--- a/lib/thermite/cargo.rb
+++ b/lib/thermite/cargo.rb
@@ -56,7 +56,8 @@ module Thermite
     def run_cargo_rustc(target)
       cargo_args = %w(rustc)
       if config.cargo_workspace_member
-        cargo_args.push('--manifest-path', config.cargo_workspace_member)
+        manifest = File.join(config.cargo_workspace_member, 'Cargo.toml')
+        cargo_args.push('--manifest-path', manifest)
       end
       cargo_args << '--release' if target == 'release'
       cargo_args.push(*cargo_rustc_args)

--- a/lib/thermite/cargo.rb
+++ b/lib/thermite/cargo.rb
@@ -55,6 +55,9 @@ module Thermite
     #
     def run_cargo_rustc(target)
       cargo_args = %w(rustc)
+      if config.cargo_workspace_member
+        cargo_args.push('--manifest-path', config.cargo_workspace_member)
+      end
       cargo_args << '--release' if target == 'release'
       cargo_args.push(*cargo_rustc_args)
       run_cargo(*cargo_args)

--- a/lib/thermite/config.rb
+++ b/lib/thermite/config.rb
@@ -169,6 +169,22 @@ module Thermite
     end
 
     #
+    # The absolute path to the `Cargo.toml` file. The path depends on the existence of the
+    # `cargo_workspace_member` configuration option.
+    #
+    def cargo_toml_path
+      @cargo_toml_path ||= begin
+        components = if (member_path = @options[:cargo_workspace_member])
+          [member_path, 'Cargo.toml']
+        else
+          ['Cargo.toml']
+        end
+
+        rust_path(*components)
+      end
+    end
+
+    #
     # Path to the Rust shared library in the context of the Ruby project.
     #
     def ruby_extension_path
@@ -198,7 +214,7 @@ module Thermite
     # Parsed TOML object (courtesy of `tomlrb`).
     #
     def toml
-      @toml ||= Tomlrb.load_file(rust_path('Cargo.toml'), symbolize_keys: true)
+      @toml ||= Tomlrb.load_file(cargo_toml_path, symbolize_keys: true)
     end
 
     #

--- a/lib/thermite/config.rb
+++ b/lib/thermite/config.rb
@@ -169,16 +169,21 @@ module Thermite
     end
 
     #
+    # If run in a multi-crate environment, the Cargo workspace member that contains the
+    # Ruby extension.
+    #
+    def cargo_workspace_member
+      @cargo_workspace_member ||= @options[:cargo_workspace_member]
+    end
+
+    #
     # The absolute path to the `Cargo.toml` file. The path depends on the existence of the
     # `cargo_workspace_member` configuration option.
     #
     def cargo_toml_path
       @cargo_toml_path ||= begin
-        components = if (member_path = @options[:cargo_workspace_member])
-          [member_path, 'Cargo.toml']
-        else
-          ['Cargo.toml']
-        end
+        components = ['Cargo.toml']
+        components.unshift(cargo_workspace_member) if cargo_workspace_member
 
         rust_path(*components)
       end

--- a/lib/thermite/tasks.rb
+++ b/lib/thermite/tasks.rb
@@ -63,6 +63,8 @@ module Thermite
     #     - `version` - the crate version from the `Cargo.toml` file
     # * `cargo_project_path` - the path to the Cargo project. Defaults to the current
     #   working directory.
+    # * `cargo_workspace_member` - if set, the relative path to the Cargo workspace member. Usually
+    #   used when it is part of a repository containing multiple crates.
     # * `github_releases` - whether to look for rust binaries via GitHub releases when installing
     #   the gem, and `cargo` is not found. Defaults to `false`.
     # * `github_release_type` - when `github_releases` is `true`, the mode to use to download the

--- a/test/lib/thermite/cargo_test.rb
+++ b/test/lib/thermite/cargo_test.rb
@@ -37,7 +37,7 @@ module Thermite
     def test_run_cargo_rustc_with_workspace_member
       mock_module.config.stubs(:dynamic_linker_flags).returns('')
       mock_module.config.stubs(:cargo_workspace_member).returns('foo/bar')
-      mock_module.expects(:run_cargo).with('rustc', '--manifest-path', 'foo/bar').once
+      mock_module.expects(:run_cargo).with('rustc', '--manifest-path', 'foo/bar/Cargo.toml').once
       mock_module.run_cargo_rustc('debug')
     end
 

--- a/test/lib/thermite/cargo_test.rb
+++ b/test/lib/thermite/cargo_test.rb
@@ -34,6 +34,13 @@ module Thermite
       mock_module.run_cargo_rustc('release')
     end
 
+    def test_run_cargo_rustc_with_workspace_member
+      mock_module.config.stubs(:dynamic_linker_flags).returns('')
+      mock_module.config.stubs(:cargo_workspace_member).returns('foo/bar')
+      mock_module.expects(:run_cargo).with('rustc', '--manifest-path', 'foo/bar').once
+      mock_module.run_cargo_rustc('debug')
+    end
+
     def test_run_cargo_rustc_with_dynamic_linker_flags
       mock_module.config.stubs(:dynamic_linker_flags).returns('foo bar')
       if RbConfig::CONFIG['target_os'] == 'mingw32'

--- a/test/lib/thermite/config_test.rb
+++ b/test/lib/thermite/config_test.rb
@@ -109,6 +109,12 @@ module Thermite
       assert_equal '/tmp/foobar/baz/quux', config.rust_path('baz', 'quux')
     end
 
+    def test_cargo_toml_path_with_workspace_member
+      FileUtils.stubs(:pwd).returns('/tmp/foobar')
+      config(cargo_workspace_member: 'baz')
+      assert_equal '/tmp/foobar/baz/Cargo.toml', config.cargo_toml_path
+    end
+
     def test_default_git_tag_regex
       assert_equal described_class::DEFAULT_TAG_REGEX, config.git_tag_regex
     end


### PR DESCRIPTION
Adds a new config variable, `cargo_workspace_member`, which is the path relative to the `cargo_project_path` directory where the member crate is located.

Fixes #29.

CC: @matthiasbeyer