### PR TITLE
The binary lives in the "deps" folder

### DIFF
--- a/lib/thermite/tasks.rb
+++ b/lib/thermite/tasks.rb
@@ -123,7 +123,7 @@ module Thermite
         if cargo
           profile = ENV.fetch('CARGO_PROFILE', 'release')
           run_cargo_rustc(profile)
-          FileUtils.cp(config.cargo_target_path(profile, "deps", config.shared_library),
+          FileUtils.cp(config.cargo_target_path(profile, 'deps', config.shared_library),
                        config.ruby_path('lib'))
         elsif !download_binary_from_custom_uri && !download_binary_from_github_release
           inform_user_about_cargo

--- a/lib/thermite/tasks.rb
+++ b/lib/thermite/tasks.rb
@@ -123,7 +123,7 @@ module Thermite
         if cargo
           profile = ENV.fetch('CARGO_PROFILE', 'release')
           run_cargo_rustc(profile)
-          FileUtils.cp(config.cargo_target_path(profile, config.shared_library),
+          FileUtils.cp(config.cargo_target_path(profile, "deps", config.shared_library),
                        config.ruby_path('lib'))
         elsif !download_binary_from_custom_uri && !download_binary_from_github_release
           inform_user_about_cargo


### PR DESCRIPTION
This fixes an error for me where the `thermite:build` task does not find the binary.

I'm not sure whether this breaks other things.