### PR TITLE
Always pass --lib to cargo with link-args

### DIFF
--- a/lib/thermite/cargo.rb
+++ b/lib/thermite/cargo.rb
@@ -114,6 +114,7 @@ EOM
       args = []
       unless config.dynamic_linker_flags == '' || config.target_os == 'mingw32'
         args.push(
+          '--lib',
           '--',
           '-C',
           "link-args=#{config.dynamic_linker_flags}"

--- a/test/lib/thermite/cargo_test.rb
+++ b/test/lib/thermite/cargo_test.rb
@@ -46,7 +46,7 @@ module Thermite
       if RbConfig::CONFIG['target_os'] == 'mingw32'
         mock_module.expects(:run_cargo).with('rustc').once
       else
-        mock_module.expects(:run_cargo).with('rustc', '--', '-C', 'link-args=foo bar').once
+        mock_module.expects(:run_cargo).with('rustc', '--lib', '--', '-C', 'link-args=foo bar').once
       end
       mock_module.run_cargo_rustc('debug')
     end


### PR DESCRIPTION
Cargo will throw an error when the target of the compilation is
ambiguous. This leads to an error when there's an additional main.rs,
e.g. for easy testing during development. Specifying `--lib` makes it
clear that we only want to build the library.

Before

```
~/.cargo/bin/cargo rustc --release -- -C link-args=-Wl,-undefined,dynamic_lookup
error: extra arguments to `rustc` can only be passed to one target,
consider filtering
```

After

```
~/.cargo/bin/cargo rustc --release --lib -- -C link-args=-Wl,-undefined,dynamic_lookup
```

Versions:
```
rustc 1.17.0 (56124baa9 2017-04-24)
cargo 0.18.0 (fe7b0cdcf 2017-04-24)
Darwin host 16.5.0 Darwin Kernel Version 16.5.0: Fri Mar  3 16:52:33 PST 2017; root:xnu-3789.51.2~3/RELEASE_X86_64 x86_64
```