### PR TITLE
Relax semantic versioning strictness

### DIFF
--- a/lib/thermite/config.rb
+++ b/lib/thermite/config.rb
@@ -216,7 +216,7 @@ module Thermite
     #
     # The basic semantic versioning format.
     #
-    DEFAULT_TAG_REGEX = /^(v\d+\.\d+\.\d+)$/
+    DEFAULT_TAG_REGEX = /^(v?(?:\d+\.){2,3}(?:\d+){1}(?:[.-][a-z]+\d+)?)$/
 
     #
     # The format (as a regular expression) that git tags containing Rust binary


### PR DESCRIPTION
Allows for matching:
0.3.2
v0.3.2
v0.3.0-rc1
v0.3.2.beta13
0.5.3.alpha1
0.5.3.1