### PR TITLE
Default the git_tag_regex option to a stricter semver format

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+* The default `git_tag_regex` conforms more to the semantic versioning 2.0.0 spec (#46)
+
 ## [0.13.0] - 2017-10-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -93,8 +93,9 @@ Possible options:
 * `git_tag_regex` - when `github_releases` is enabled and `github_release_type` is `'latest'`, a
   regular expression (expressed as a `String`) that determines which tagged releases to look for
   precompiled Rust tarballs. One group must be specified that indicates the version number to be
-  used in the tarball filename. Defaults to `vN.N.N`, where `N` is any n-digit number. In this case,
-  the group is around the entire expression.
+  used in the tarball filename. Defaults to the [semantic versioning 2.0.0
+  format](https://semver.org/spec/v2.0.0.html). In this case, the group is around the entire
+  expression.
 * `optional_rust_extension` - prints a warning to STDERR instead of raising an exception, if Cargo
   is unavailable and `github_releases` is either disabled or unavailable. Useful for projects where
   either fallback code exists, or a native extension is desirable but not required. Defaults

--- a/lib/thermite/config.rb
+++ b/lib/thermite/config.rb
@@ -19,6 +19,7 @@
 
 require 'fileutils'
 require 'rbconfig'
+require 'thermite/semver'
 require 'tomlrb'
 
 module Thermite
@@ -214,9 +215,9 @@ module Thermite
     end
 
     #
-    # The basic semantic versioning format.
+    # The default git tag regular expression (semantic versioning format).
     #
-    DEFAULT_TAG_REGEX = /^(v\d+\.\d+\.\d+)$/
+    DEFAULT_TAG_REGEX = /^(#{Thermite::SemVer::VERSION})$/
 
     #
     # The format (as a regular expression) that git tags containing Rust binary

--- a/lib/thermite/semver.rb
+++ b/lib/thermite/semver.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+#
+# Copyright (c) 2018 Mark Lee and contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+# associated documentation files (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge, publish, distribute,
+# sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or
+# substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+# NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+# DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
+# OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+module Thermite
+  #
+  # [Semantic Versioning](https://semver.org/spec/v2.0.0.html) (2.0.0) regular expression.
+  #
+  module SemVer
+    #
+    # Valid version number part (major/minor/patch).
+    #
+    NUMERIC = '(?:0|[1-9]\d*)'.freeze
+
+    #
+    # Valid identifier for pre-release versions or build metadata.
+    #
+    IDENTIFIER = '[-0-9A-Za-z][-0-9A-Za-z.]*'.freeze
+
+    #
+    # Version pre-release section, including the hyphen.
+    #
+    PRERELEASE = "-#{IDENTIFIER}".freeze
+
+    #
+    # Version build metadata section, including the plus sign.
+    #
+    BUILD_METADATA = "\\+#{IDENTIFIER}".freeze
+
+    #
+    # Semantic version-compliant regular expression.
+    #
+    VERSION = "v?#{NUMERIC}\.#{NUMERIC}\.#{NUMERIC}(?:#{PRERELEASE})?(?:#{BUILD_METADATA})?".freeze
+  end
+end

--- a/lib/thermite/tasks.rb
+++ b/lib/thermite/tasks.rb
@@ -78,8 +78,9 @@ module Thermite
     # * `git_tag_regex` - when `github_releases` is enabled and `github_release_type` is
     #   `'latest'`, a regular expression (expressed as a `String`) that determines which tagged
     #   releases to look for precompiled Rust tarballs. One group must be specified that indicates
-    #   the version number to be used in the tarball filename. Defaults to `vN.N.N`, where `N` is
-    #   any n-digit number. In this case, the group is around the entire expression.
+    #   the version number to be used in the tarball filename. Defaults to the [semantic versioning
+    #   2.0.0 format](https://semver.org/spec/v2.0.0.html). In this case, the group is around the
+    #   entire expression.
     # * `optional_rust_extension` - prints a warning to STDERR instead of raising an exception, if
     #   Cargo is unavailable and `github_releases` is either disabled or unavailable. Useful for
     #   projects where either fallback code exists, or a native extension is desirable but not

--- a/test/fixtures/github/releases.atom
+++ b/test/fixtures/github/releases.atom
@@ -6,10 +6,10 @@
   <title>Release notes from project</title>
   <updated>2016-07-10T01:57:28Z</updated>
   <entry>
-    <id>tag:github.com,2008:Repository/12345678/v0.1.12-rust</id>
+    <id>tag:github.com,2008:Repository/12345678/v0.1.12_rust</id>
     <updated>2016-07-10T01:59:24Z</updated>
-    <link rel="alternate" type="text/html" href="/ghost/project/releases/tag/v0.1.12-rust"/>
-    <title>v0.1.12-rust</title>
+    <link rel="alternate" type="text/html" href="/ghost/project/releases/tag/v0.1.12_rust"/>
+    <title>v0.1.12_rust</title>
     <content>No content.</content>
     <author>
       <name>ghost</name>
@@ -17,10 +17,10 @@
     <media:thumbnail height="30" width="30" url="about:blank"/>
   </entry>
   <entry>
-    <id>tag:github.com,2008:Repository/12345678/v0.1.11-rust</id>
+    <id>tag:github.com,2008:Repository/12345678/v0.1.11_rust</id>
     <updated>2016-07-09T22:47:09Z</updated>
-    <link rel="alternate" type="text/html" href="/ghost/project/releases/tag/v0.1.11-rust"/>
-    <title>v0.1.11-rust</title>
+    <link rel="alternate" type="text/html" href="/ghost/project/releases/tag/v0.1.11_rust"/>
+    <title>v0.1.11_rust</title>
     <content>No content.</content>
     <author>
       <name>ghost</name>

--- a/test/lib/thermite/github_release_binary_test.rb
+++ b/test/lib/thermite/github_release_binary_test.rb
@@ -111,7 +111,7 @@ module Thermite
     end
 
     def test_download_latest_binary_from_github_release
-      mock_module(github_releases: true, github_release_type: 'latest', git_tag_regex: 'v(.*)-rust')
+      mock_module(github_releases: true, github_release_type: 'latest', git_tag_regex: 'v(.*)_rust')
       stub_releases_atom
       mock_module.stubs(:download_versioned_github_release_binary).returns(StringIO.new('tarball'))
       mock_module.expects(:unpack_tarball).once
@@ -129,7 +129,7 @@ module Thermite
     end
 
     def test_download_latest_binary_from_github_release_no_tarball_found
-      mock_module(github_releases: true, github_release_type: 'latest', git_tag_regex: 'v(.*)-rust')
+      mock_module(github_releases: true, github_release_type: 'latest', git_tag_regex: 'v(.*)_rust')
       stub_releases_atom
       mock_module.stubs(:download_versioned_github_release_binary).returns(nil)
       mock_module.expects(:unpack_tarball).never

--- a/test/lib/thermite/semver_test.rb
+++ b/test/lib/thermite/semver_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+#
+# Copyright (c) 2018 Mark Lee and contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+# associated documentation files (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge, publish, distribute,
+# sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or
+# substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+# NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+# DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
+# OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+require 'thermite/semver'
+
+module Thermite
+  class SemVerTest < Minitest::Test
+    def test_valid_semantic_versions
+      # From https://github.com/malept/thermite/pull/45
+      assert semantic_version_regexp.match('0.3.2')
+      assert semantic_version_regexp.match('v0.3.2')
+      assert semantic_version_regexp.match('0.3.0-rc1')
+      assert semantic_version_regexp.match('0.3.0-rc.1')
+    end
+
+    def test_invalid_semantic_versions
+      # From https://github.com/malept/thermite/pull/45
+      assert_nil semantic_version_regexp.match('v0.3.2.beta13')
+      assert_nil semantic_version_regexp.match('0.5.3.alpha1')
+      assert_nil semantic_version_regexp.match('0.5.3.1')
+    end
+
+    def test_valid_semantic_prerelease_versions
+      # From https://semver.org/spec/v2.0.0.html#spec-item-9
+      assert semantic_version_regexp.match('1.0.0-alpha')
+      assert semantic_version_regexp.match('1.0.0-alpha.1')
+      assert semantic_version_regexp.match('1.0.0-0.3.7')
+      assert semantic_version_regexp.match('1.0.0-x.7.z.92')
+    end
+
+    def test_valid_semantic_build_metadata_versions
+      # From https://semver.org/spec/v2.0.0.html#spec-item-10
+      assert semantic_version_regexp.match('1.0.0-alpha+001')
+      assert semantic_version_regexp.match('1.0.0+20130313144700')
+      assert semantic_version_regexp.match('1.0.0-beta+exp.sha.5114f85')
+    end
+
+    def semantic_version_regexp
+      @semantic_version_regexp ||= /^#{Thermite::SemVer::VERSION}$/
+    end
+  end
+end


### PR DESCRIPTION
Should handle all valid [semver](https://semver.org/spec/v2.0.0.html) formatted versions, including those with prerelease versions and build metadata.

It's "stricter" because leading zeroes are invalid.

Closes #45.