### PR TITLE
Add docs to the README about CARGO_PROFILE

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Possible options:
   current working directory.
 * `ruby_extension_dir` - the directory relative to `ruby_project_path` where the extension is
   located. Defaults to `lib`.
+* `CARGO_PROFILE` environment variable. Set this to `debug` if you want to do a debug build of Rust code rather than the release build. For example, you can run `CARGO_PROFILE=debug rake build`.
 
 ### Example
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Possible options:
   current working directory.
 * `ruby_extension_dir` - the directory relative to `ruby_project_path` where the extension is
   located. Defaults to `lib`.
-* `CARGO_PROFILE` environment variable. Set this to `debug` if you want to do a debug build of Rust code rather than the release build. For example, you can run `CARGO_PROFILE=debug rake build`.
+* `CARGO_PROFILE` environment variable. Set this to `debug` if you want to do a debug build of Rust code rather than release build. For example, you can run `CARGO_PROFILE=debug rake build`.
 
 ### Example
 

--- a/README.md
+++ b/README.md
@@ -114,9 +114,10 @@ usable with any method of integrating Rust and Ruby that you choose.
 
 ### Debug / release build
 
-By default Thermite will do a release build of your Rust code. To do a debug build instead, set the `CARGO_PROFILE` environment variable to `debug`.
+By default Thermite will do a release build of your Rust code. To do a debug build instead,
+set the `CARGO_PROFILE` environment variable to `debug`.
 
-For example, you can run `CARGO_PROFILE=debug rake build`.
+For example, you can run `CARGO_PROFILE=debug rake thermite:build`.
 
 ### Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ Possible options:
   current working directory.
 * `ruby_extension_dir` - the directory relative to `ruby_project_path` where the extension is
   located. Defaults to `lib`.
-* `CARGO_PROFILE` environment variable. Set this to `debug` if you want to do a debug build of Rust code rather than release build. For example, you can run `CARGO_PROFILE=debug rake build`.
 
 ### Example
 
@@ -112,6 +111,12 @@ Using the cliché Rust+Ruby example, the [`rusty_blank`](https://github.com/male
 repository contains an example of using Thermite with [ruru](https://github.com/d-unseductable/ruru)
 to provide a `String.blank?` speedup extension. While the example uses ruru, this gem should be
 usable with any method of integrating Rust and Ruby that you choose.
+
+### Debug / release build
+
+By default Thermite will do a release build of your Rust code. To do a debug build instead, set the `CARGO_PROFILE` environment variable to `debug`.
+
+For example, you can run `CARGO_PROFILE=debug rake build`.
 
 ### Troubleshooting
 


### PR DESCRIPTION
In our Ruby project that uses Rust, we integrate Thermite into our build process like this:

```
task build: [:check_ruby_opts, 'thermite:build']
```

It's useful to be able to iterate on a debug build during development. I change some Rust code, run Ruby tests that call it, and repeat.

Running `CARGO_PROFILE=debug rake build` takes 11s in our project, compared to `rake build` which takes 45s.

I found about the `CARGO_PROFILE` variable by [reading code](https://github.com/malept/thermite/blob/ca07a5141779a21524be06687f423312cab2d836/lib/thermite/tasks.rb#L126). Documenting it in the readme might be useful. This is a big boost to my productivity and might be useful to others.